### PR TITLE
Update README with -loader suffix to support webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ``` javascript
-var exportsOfFile = require("coffee-redux!./file.coffee");
+var exportsOfFile = require("coffee-redux-loader!./file.coffee");
 // => return exports of executed and compiled file.coffee
 ```
 


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra @SpaceK33z